### PR TITLE
MW-750 Wrap system profiling info in "tag[]"

### DIFF
--- a/Sparkle/SUSystemProfiler.m
+++ b/Sparkle/SUSystemProfiler.m
@@ -37,6 +37,11 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     return [[NSDictionary alloc] initWithContentsOfFile:path];
 }
 
++ (NSString*) getKey:(NSString *)keyString
+{
+    return [NSString stringWithFormat:@"tag[%@]", keyString];
+}
+
 + (NSArray<NSDictionary<NSString *, NSString *> *> *)systemProfileArrayForHost:(SUHost *)host
 {
     NSDictionary<NSString *, NSString *> *modelTranslation = [self modelTranslationTable];
@@ -51,7 +56,7 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     // OS version
     NSString *currentSystemVersion = [SUOperatingSystem systemVersionString];
     if (currentSystemVersion != nil) {
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerOperatingSystemVersionKey, @"OS Version", currentSystemVersion, currentSystemVersion] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerOperatingSystemVersionKey], @"OS Version", currentSystemVersion, currentSystemVersion] forKeys:profileDictKeys]];
     }
 
     // CPU type (decoder info for values found here is in mach/machine.h)
@@ -66,7 +71,7 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
 			case CPU_TYPE_POWERPC:	visibleCPUType = @"PowerPC";	break;
 			default:				visibleCPUType = @"Unknown";	break;
         }
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUTypeKey, @"CPU Type", @(value), visibleCPUType] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerCPUTypeKey], @"CPU Type", @(value), visibleCPUType] forKeys:profileDictKeys]];
     }
     error = sysctlbyname("hw.cpu64bit_capable", &value, &length, NULL, 0);
     if (error != 0) {
@@ -80,7 +85,7 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
 
     if (error == 0) {
         is64bit = value == 1;
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPU64bitKey, @"CPU is 64-Bit?", @(is64bit), is64bit ? @"Yes" : @"No"] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerCPU64bitKey], @"CPU is 64-Bit?", @(is64bit), is64bit ? @"Yes" : @"No"] forKeys:profileDictKeys]];
     }
     error = sysctlbyname("hw.cpusubtype", &value, &length, NULL, 0);
     if (error == 0) {
@@ -100,7 +105,7 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
         } else {
             visibleCPUSubType = @"Other";
         }
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUSubtypeKey, @"CPU Subtype", @(value), visibleCPUSubType] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerCPUSubtypeKey], @"CPU Subtype", @(value), visibleCPUSubType] forKeys:profileDictKeys]];
     }
     error = sysctlbyname("hw.model", NULL, &length, NULL, 0);
     if (error == 0) {
@@ -113,7 +118,7 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
                 if (visibleModelName == nil) {
                     visibleModelName = rawModelName;
                 }
-                [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerHardwareModelKey, @"Mac Model", rawModelName, visibleModelName] forKeys:profileDictKeys]];
+                [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerHardwareModelKey], @"Mac Model", rawModelName, visibleModelName] forKeys:profileDictKeys]];
             }
             free(cpuModel);
         }
@@ -122,24 +127,24 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     // Number of CPUs
     error = sysctlbyname("hw.ncpu", &value, &length, NULL, 0);
     if (error == 0) {
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUCountKey, @"Number of CPUs", @(value), @(value)] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerCPUCountKey], @"Number of CPUs", @(value), @(value)] forKeys:profileDictKeys]];
     }
 
     // User preferred language
     NSUserDefaults *defs = [NSUserDefaults standardUserDefaults];
     NSArray *languages = [defs objectForKey:@"AppleLanguages"];
     if ([languages count] > 0) {
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerPreferredLanguageKey, @"Preferred Language", [languages objectAtIndex:0], [languages objectAtIndex:0]] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerPreferredLanguageKey], @"Preferred Language", [languages objectAtIndex:0], [languages objectAtIndex:0]] forKeys:profileDictKeys]];
     }
 
     // Application sending the request
     NSString *appName = [host name];
     if (appName) {
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerApplicationNameKey, @"Application Name", appName, appName] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerApplicationNameKey], @"Application Name", appName, appName] forKeys:profileDictKeys]];
     }
     NSString *appVersion = [host version];
     if (appVersion) {
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerApplicationVersionKey, @"Application Version", appVersion, appVersion] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerApplicationVersionKey], @"Application Version", appVersion, appVersion] forKeys:profileDictKeys]];
     }
 
     // Number of displays?
@@ -149,7 +154,7 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     size_t hz_size = sizeof(unsigned long);
     if (sysctlbyname("hw.cpufrequency", &hz, &hz_size, NULL, 0) == 0) {
         unsigned long mhz = hz / 1000000;
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerCPUFrequencyKey, @"CPU Speed (MHz)", @(mhz), @(mhz / 1000.)] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerCPUFrequencyKey], @"CPU Speed (MHz)", @(mhz), @(mhz / 1000.)] forKeys:profileDictKeys]];
     }
 
     // amount of RAM
@@ -157,7 +162,7 @@ static NSString *const SUSystemProfilerPreferredLanguageKey = @"lang";
     size_t bytes_size = sizeof(unsigned long);
     if (sysctlbyname("hw.memsize", &bytes, &bytes_size, NULL, 0) == 0) {
         double megabytes = bytes / (1024. * 1024.);
-        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[SUSystemProfilerMemoryKey, @"Memory (MB)", @(megabytes), @(megabytes)] forKeys:profileDictKeys]];
+        [profileArray addObject:[NSDictionary dictionaryWithObjects:@[[SUSystemProfiler getKey:SUSystemProfilerMemoryKey], @"Memory (MB)", @(megabytes), @(megabytes)] forKeys:profileDictKeys]];
     }
 
     return [profileArray copy];


### PR DESCRIPTION
Sparkle is shooting system profiling info along with the appcast url. Our backend can take them in but requires them to be wrapped in tag[]. Modified slightly Sparkle to wrap those tags.